### PR TITLE
Pass through additional HTTP options to `listen` method

### DIFF
--- a/lib/app-service.js
+++ b/lib/app-service.js
@@ -174,9 +174,12 @@ AppService.prototype.setHomeserverToken = function(hsToken) {
 /**
  * Begin listening on the specified port.
  * @param {Number} port The port to listen on.
+ * @param {String} hostname Optional hostname to listen on
+ * @param {Number} backlog Maximum length of the queue of pending connections
+ * @param {Function} callback The callback for the "listening" event
  */
-AppService.prototype.listen = function(port) {
-    this.app.listen(port);
+AppService.prototype.listen = function(port, hostname, backlog, callback) {
+    this.app.listen(port, hostname, backlog, callback);
 };
 
 /** The application service class */


### PR DESCRIPTION
Currently only the `port` option is passed through, but the `listen`
method takes additional parameters:
- http://expressjs.com/en/4x/api.html#app.listen
- https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback

This is so I can eventually do https://github.com/matrix-org/matrix-appservice-irc/issues/95 by not binding promiscuously.