### PR TITLE
Access token redaction

### DIFF
--- a/lib/app-service.js
+++ b/lib/app-service.js
@@ -31,9 +31,9 @@ function AppService(config) {
                  *   console.log(logLine);
                  * });
                  */
-                var redacted_str = str.replace(/access_token=.*?(&|\s|$)/, "access_token=<REDACTED>$1");
+                var redactedStr = str.replace(/access_token=.*?(&|\s|$)/, "access_token=<REDACTED>$1");
 
-                self.emit("http-log", redacted_str);
+                self.emit("http-log", redactedStr);
             }
         }
     }));

--- a/lib/app-service.js
+++ b/lib/app-service.js
@@ -5,6 +5,9 @@ var morgan = require("morgan");
 var util = require("util");
 var EventEmitter = require("events").EventEmitter;
 
+var ACCESS_TOKEN_RE = /(\?.*access(?:_|%5[Ff])token=)([0-9a-z]*)([^&]*)(.*)$/;
+var REDACTED_STR = '<redacted>';
+
 /**
  * Construct a new application service.
  * @constructor
@@ -31,6 +34,13 @@ function AppService(config) {
                  *   console.log(logLine);
                  * });
                  */
+
+                var sep = str.split(ACCESS_TOKEN_RE);
+
+                sep[2] = REDACTED_STR;
+                str = sep.join('');
+                str = str.replace('\n','');
+
                 self.emit("http-log", str);
             }
         }

--- a/lib/app-service.js
+++ b/lib/app-service.js
@@ -5,7 +5,13 @@ var morgan = require("morgan");
 var util = require("util");
 var EventEmitter = require("events").EventEmitter;
 
-var ACCESS_TOKEN_RE = /(\?.*access(?:_|%5[Ff])token=)([0-9a-z]*)([^&]*)(.*)$/;
+// Groups a HTTP log line into stuff before access token, token and stuff after
+//  Example grouping : 
+//      2016-07-26 13:35:41 INFO:IrcBridge ::ffff:127.0.0.1 - - [26/Jul/2016:13:35:41 +0000] "PUT /transactions/146?access_token=
+//      [access token here]
+//       HTTP/1.1" 200 2 "-" "Synapse/0.16.1-r1 (b=master,t=v0.16.1-r1,0870588)"
+var ACCESS_TOKEN_RE = /^(.*\?.*access(?:_|%5[Ff])token=)([0-9a-z]*)([^&]*)$/;
+// The string to replace the access token with when logging
 var REDACTED_STR = '<redacted>';
 
 /**
@@ -34,14 +40,20 @@ function AppService(config) {
                  *   console.log(logLine);
                  * });
                  */
+                var sep = str.match(ACCESS_TOKEN_RE);
+                sep.shift(); // Remove entire match as first element
 
-                var sep = str.split(ACCESS_TOKEN_RE);
+                var redacted_str = str;
 
-                sep[2] = REDACTED_STR;
-                str = sep.join('');
-                str = str.replace('\n','');
+                // Will redact if match successful
+                if (sep && sep.length == 3) {
+                    sep[1] = REDACTED_STR;
 
-                self.emit("http-log", str);
+                    redacted_str = sep.join('');
+                    redacted_str = redacted_str.replace('\n','');
+                }
+
+                self.emit("http-log", redacted_str);
             }
         }
     }));

--- a/lib/app-service.js
+++ b/lib/app-service.js
@@ -5,15 +5,6 @@ var morgan = require("morgan");
 var util = require("util");
 var EventEmitter = require("events").EventEmitter;
 
-// Groups a HTTP log line into stuff before access token, token and stuff after
-//  Example grouping : 
-//      2016-07-26 13:35:41 INFO:IrcBridge ::ffff:127.0.0.1 - - [26/Jul/2016:13:35:41 +0000] "PUT /transactions/146?access_token=
-//      [access token here]
-//       HTTP/1.1" 200 2 "-" "Synapse/0.16.1-r1 (b=master,t=v0.16.1-r1,0870588)"
-var ACCESS_TOKEN_RE = /^(.*\?.*access(?:_|%5[Ff])token=)([0-9a-z]*)([^&]*)$/;
-// The string to replace the access token with when logging
-var REDACTED_STR = '<redacted>';
-
 /**
  * Construct a new application service.
  * @constructor
@@ -40,18 +31,7 @@ function AppService(config) {
                  *   console.log(logLine);
                  * });
                  */
-                var sep = str.match(ACCESS_TOKEN_RE);
-                sep.shift(); // Remove entire match as first element
-
-                var redacted_str = str;
-
-                // Will redact if match successful
-                if (sep && sep.length == 3) {
-                    sep[1] = REDACTED_STR;
-
-                    redacted_str = sep.join('');
-                    redacted_str = redacted_str.replace('\n','');
-                }
+                var redacted_str = str.replace(/access_token=.*?(&|\s|$)/, "access_token=<REDACTED>$1");
 
                 self.emit("http-log", redacted_str);
             }


### PR DESCRIPTION
Fix for #4 

Access token is now redacted from the log in a similar way to [Synapse](https://github.com/matrix-org/synapse/blob/ba0406d10da32ebebf4185f01841f236371e0ae8/synapse/http/site.py#L44).