### PR TITLE
Added support for HTTPS listener.

### DIFF
--- a/lib/app-service.js
+++ b/lib/app-service.js
@@ -4,6 +4,8 @@ var bodyParser = require('body-parser');
 var morgan = require("morgan");
 var util = require("util");
 var EventEmitter = require("events").EventEmitter;
+var fs = require('fs');
+var https = require('https');
 
 /**
  * Construct a new application service.
@@ -181,7 +183,31 @@ AppService.prototype.setHomeserverToken = function(hsToken) {
  * @param {Function} callback The callback for the "listening" event
  */
 AppService.prototype.listen = function(port, hostname, backlog, callback) {
-    this.app.listen(port, hostname, backlog, callback);
+    const tlsKey = process.env.MATRIX_AS_TLS_KEY;
+    const tlsCert = process.env.MATRIX_AS_TLS_CERT;
+    if (tlsKey || tlsCert) {
+        if (!(tlsKey && tlsCert)) {
+            throw new Error("MATRIX_AS_TLS_KEY and MATRIX_AS_TLS_CERT should be defined together!");
+        }
+
+        if (!fs.existsSync(tlsKey)) {
+            throw new Error("Could not open MATRIX_AS_TLS_KEY: " + tlsKey);
+        }
+
+        if (!fs.existsSync(tlsCert)) {
+            throw new Error("Could not open MATRIX_AS_TLS_CERT: " + tlsCert);
+        }
+
+        var options = {
+               key  : fs.readFileSync(tlsKey),
+               cert : fs.readFileSync(tlsCert)
+        };
+
+        https.createServer(options, this.app).listen(port, hostname, backlog, callback);
+    }
+    else {
+        this.app.listen(port, hostname, backlog, callback);
+    }
 };
 
 /** The application service class */


### PR DESCRIPTION
If the MATRIX_AS_TLS_KEY and MATRIX_AS_TLS_CERT environment variables are
defined and point to valid tls key and cert files, the AS will listen using
https rather than http.