### PR TITLE
npm audit fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   "author": "matrix.org",
   "license": "Apache-2.0",
   "dependencies": {
-    "body-parser": "~1.12.0",
-    "express": "~4.12.0",
+    "body-parser": "^1.18.3",
+    "express": "^4.16.3",
     "js-yaml": "^3.2.7",
-    "morgan": "~1.5.1",
-    "request": "~2.53.0"
+    "morgan": "^1.9.1",
+    "request": "^2.88.0"
   },
   "devDependencies": {
     "jsdoc": "^3.3.2",


### PR DESCRIPTION
There are currently 21 vulnerabilities (8 low, 9 moderate, **4 high**) in this package.

I suggest updating dependencies, release new version and subsequently update version in upstream modules (matrix-appservice-bridge, matrix-puppet-bridge).