### PR TITLE
Expose express app

### DIFF
--- a/changelog.d/26.feature
+++ b/changelog.d/26.feature
@@ -1,0 +1,1 @@
+Expose `AppService.app` so that services may add their own Express request handlers.

--- a/src/app-service.ts
+++ b/src/app-service.ts
@@ -40,7 +40,7 @@ export class AppService extends EventEmitter {
      * });
      */
 
-    private app: Application;
+    public readonly app: Application;
     private server?: Server;
     private lastProcessedTxnId = "";
     /**


### PR DESCRIPTION
So that we can access it from within matrix-appservice-bridge without TS complaining.